### PR TITLE
Keyframe css rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = postcss.plugin('postcss-prepend-selector', function (opts) {
     return function (css) {
         css.walkRules(function (rule) {
             rule.selectors = rule.selectors.map( function (selector) {
+                if(/^\d*\%$|^from$|^to$/.test(selector)) {
+                    // This is part of a keyframe
+                    return selector;
+                }
                 return opts.selector + selector;
             });
         });

--- a/test.js
+++ b/test.js
@@ -22,3 +22,9 @@ test('Prepend selectors', t => {
         selector: '.selector '
     });
 });
+
+test('Skip keyframe rules', t => {
+    return run(t, '0%, from {} 100%, to {}', '0%, from {} 100%, to {}', {
+        selector: '.selector '
+    });
+});


### PR DESCRIPTION
Currently, the prepend-selector plugin also prepends to keyframe timing rules.

This changes adds a check that sees if the current css rule is a keyframe rule.
Keyframe rules should be skipped by this plugin :)

Example of skipped rules:

```
0% {}
from {}
to {}
75% {}
```
