### PR TITLE
Do not prepend the selector if its already at the start of the rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ module.exports = postcss.plugin('postcss-prepend-selector', function (opts) {
                     // This is part of a keyframe
                     return selector;
                 }
+
+                if (selector.startsWith(opts.selector.trim())) {
+                    return selector;
+                }
+
                 return opts.selector + selector;
             });
         });

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   },
   "homepage": "https://github.com/ledniy/postcss-prepend-selector",
   "dependencies": {
-    "postcss": "^5.0.10"
+    "postcss": "^5.2.14"
   },
   "devDependencies": {
-    "ava": "^0.7.0",
+    "ava": "^0.18.0",
     "eslint": "^1.10.2"
   },
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -6,25 +6,25 @@ import plugin from './';
 function run(t, input, output, opts = {}) {
     return postcss([plugin(opts)]).process(input)
         .then(result => {
-            t.same(result.css, output);
-            t.same(result.warnings().length, 0);
+            t.is(result.css, output);
+            t.is(result.warnings().length, 0);
         });
 }
 
-test('Prepend selector', t => {
-    return run(t, 'a{ }', '.selector a{ }', {
-        selector: '.selector '
-    });
-});
+const selector = '.selector ';
 
-test('Prepend selectors', t => {
-    return run(t, 'a, .example{ }', '.selector a, .selector .example{ }', {
-        selector: '.selector '
-    });
-});
+test('Prepend selector', t =>
+  run(t, 'a{ }', '.selector a{ }', { selector })
+);
 
-test('Skip keyframe rules', t => {
-    return run(t, '0%, from {} 100%, to {}', '0%, from {} 100%, to {}', {
-        selector: '.selector '
-    });
-});
+test('Prepend selectors', t =>
+  run(t, 'a, .example{ }', '.selector a, .selector .example{ }', { selector })
+);
+
+test('Should not prepend if class is already there', t =>
+  run(t, '.selector.example{ }', '.selector.example{ }', { selector })
+);
+
+test('Skip keyframe rules', t =>
+  run(t, '0%, from {} 100%, to {}', '0%, from {} 100%, to {}', { selector })
+);


### PR DESCRIPTION
Hey, we have a issue where we need to access the class we are prepending and chain some other classes to it. This change will check to see if the class already exists and skip it if does.

Thanks for the module!